### PR TITLE
Scripts to imports + general "options" property

### DIFF
--- a/c3.html
+++ b/c3.html
@@ -1,0 +1,11 @@
+<!--
+@license MIT
+Copyright (c) 2016 Horacio "LostInBrittany" Gonzalez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<script src="../c3/c3.min.js"></script>

--- a/d3.html
+++ b/d3.html
@@ -1,0 +1,11 @@
+<!--
+@license MIT
+Copyright (c) 2016 Horacio "LostInBrittany" Gonzalez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<script src="../d3/d3.min.js"></script>

--- a/granite-c3.html
+++ b/granite-c3.html
@@ -36,18 +36,18 @@ Typical usage:
           width: 100%;
           height: 100%;
         }
+
         #chart {
           display: block;
           width: 100%;
           height: 100%;
         }
+
         .c3 svg{font:10px sans-serif;-webkit-tap-highlight-color:transparent}.c3 line,.c3 path{fill:none;stroke:#000}.c3 text{-webkit-user-select:none;-moz-user-select:none;user-select:none}.c3-bars path,.c3-event-rect,.c3-legend-item-tile,.c3-xgrid-focus,.c3-ygrid{shape-rendering:crispEdges}.c3-chart-arc path{stroke:#fff}.c3-chart-arc text{fill:#fff;font-size:13px}.c3-grid line{stroke:#aaa}.c3-grid text{fill:#aaa}.c3-xgrid,.c3-ygrid{stroke-dasharray:3 3}.c3-text.c3-empty{fill:gray;font-size:2em}.c3-line{stroke-width:1px}.c3-circle._expanded_{stroke-width:1px;stroke:#fff}.c3-selected-circle{fill:#fff;stroke-width:2px}.c3-bar{stroke-width:0}.c3-bar._expanded_{fill-opacity:.75}.c3-target.c3-focused{opacity:1}.c3-target.c3-focused path.c3-line,.c3-target.c3-focused path.c3-step{stroke-width:2px}.c3-target.c3-defocused{opacity:.3!important}.c3-region{fill:#4682b4;fill-opacity:.1}.c3-brush .extent{fill-opacity:.1}.c3-legend-item{font-size:12px}.c3-legend-item-hidden{opacity:.15}.c3-legend-background{opacity:.75;fill:#fff;stroke:#d3d3d3;stroke-width:1}.c3-title{font:14px sans-serif}.c3-tooltip-container{z-index:10}.c3-tooltip{border-collapse:collapse;border-spacing:0;background-color:#fff;empty-cells:show;-webkit-box-shadow:7px 7px 12px -9px #777;-moz-box-shadow:7px 7px 12px -9px #777;box-shadow:7px 7px 12px -9px #777;opacity:.9}.c3-tooltip tr{border:1px solid #CCC}.c3-tooltip th{background-color:#aaa;font-size:14px;padding:2px 5px;text-align:left;color:#FFF}.c3-tooltip td{font-size:13px;padding:3px 6px;background-color:#fff;border-left:1px dotted #999}.c3-tooltip td>span{display:inline-block;width:10px;height:10px;margin-right:6px}.c3-tooltip td.value{text-align:right}.c3-area{stroke-width:0;opacity:.2}.c3-chart-arcs-title{dominant-baseline:middle;font-size:1.3em}.c3-chart-arcs .c3-chart-arcs-background{fill:#e0e0e0;stroke:none}.c3-chart-arcs .c3-chart-arcs-gauge-unit{fill:#000;font-size:16px}.c3-chart-arcs .c3-chart-arcs-gauge-max,.c3-chart-arcs .c3-chart-arcs-gauge-min{fill:#777}.c3-chart-arc .c3-gauge-value{fill:#000}
       </style>
-      
+
       <div id="chart"></div>      
     </template>
-
-
 
     <script>
       Polymer({
@@ -55,96 +55,70 @@ Typical usage:
 
         properties: {
           data: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           axis: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           grid: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           regions: {
             type: Array,
-            value: function() {
-              return []; 
-            }
-          }, 
+          },
+           
           legend: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           tooltip: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           point: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           area: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           bar: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           pie: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           donnut: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           gauge: {
-            type: Object,
-            value: function() {
-              return {}; 
-            }
+            type: Object
           },
+          
           chart:  {
             type: Object,
             notify: true    
-          },      
+          },
+          
+          options: {
+            type: Object
+          }
         },
-
-        observers: [
-        ],
-
-        // Element lifecycle
 
         ready: function() {
           this.scopeSubtree(this.$.chart, true);
         },
 
         attached: function() {
-          console.debug("[granite-c3] data", this.data)
-          console.debug("[granite-c3] axis", this.axis)
-          this.chart = c3.generate({
+          var options = this.options;
+          var explicitBindings = {
             bindto: this.$.chart,
             data: this.data,
             axis: this.axis,
@@ -158,16 +132,23 @@ Typical usage:
             pie: this.pie,
             donnut: this.donnut,
             gauge: this.gauge,
-          });
-          console.debug("[granite-c3] chart", this.chart)
+          };
+
+          for (var key in explicitBindings) {
+            if (explicitBindings[key]) {
+              options[key] = explicitBindings[key];
+            }
+          }
+
+          this.chart = c3.generate(options);
+
           return this.chart;
         },
 
         detached: function() {
           if (this.chart)
             return this.chart.destroy();
-        },       
-
+        }
       });
     </script>
 

--- a/granite-c3.html
+++ b/granite-c3.html
@@ -10,8 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -->
 <link rel="import" href="../polymer/polymer.html">
 
-<script src="../d3/d3.min.js"></script>
-<script src="../c3/c3.min.js"></script>
+<link rel="import" href="d3.html">
+<link rel="import" href="c3.html">
 
 <!--
 `<granite-c3>` is lightweight element wrapping-up [C3.js](http://c3js.org/), D3-based chart library.


### PR DESCRIPTION
Moved the script imports from `granite-c3.html` to their own files and changed them to HTML imports. This should help prevent collisions in script imports.

Added an options property so that it is possible to create a js object and pass in the values. Much faster way to write. Additionally, if c3 is updated to expose new values, we won't have to go through the work of exposing them.

e.g. the [`interaction`](http://c3js.org/reference.html#interaction-enabled) property is not exposed.
