### PR TITLE
Fix for automatic vertical resizing of chart

### DIFF
--- a/granite-c3.html
+++ b/granite-c3.html
@@ -233,7 +233,7 @@
           }
         }
 
-        if (this.fixHeightResizing) {
+        if (this.fixVerticalResizing) {
           this.options.onresized = function() {
             this.selectChart.style('max-height', 'none');
           }

--- a/granite-c3.html
+++ b/granite-c3.html
@@ -184,6 +184,13 @@
               {name: 'c3', url: '../c3/c3.min.js'},
             ],
           },
+          /**
+           * If true, uses js hack to fix automatic vertical resizing. See https://github.com/c3js/c3/issues/1450#issuecomment-322841360
+           */ 
+           fixVerticalResizing: {
+             type: Boolean,
+             value: false
+           }
         };
       }
 
@@ -225,6 +232,13 @@
             this.options[key] = explicitBindings[key];
           }
         }
+
+        if (this.fixHeightResizing) {
+          this.options.onresized = function() {
+            this.selectChart.style('max-height', 'none');
+          }
+        }
+
         console.log('[granite-c3] _initChart', this.options);
 
         this.chart = c3.generate(this.options);


### PR DESCRIPTION
I have added a fix for the vertical resizing of a chart to its parent according to https://github.com/c3js/c3/issues/1450#issuecomment-322841360

This is possibly a bug in C3, but according to some issues it does not seem to be fixed there anytime soon.

To activate this set the fixVerticalResizing property on the granite-c3 tag
ex.: <granite-c3 fix-vertical-resizing>...